### PR TITLE
Fix Slate URLs

### DIFF
--- a/source/projects/slate.md
+++ b/source/projects/slate.md
@@ -1,7 +1,7 @@
 ---
 title: Slate
-repo: tripit/slate
-homepage: http://tripit.github.io/slate/
+repo: lord/slate
+homepage: http://lord.github.io/slate/
 language: JavaScript, Ruby
 license: Apache License, Version 2.0
 


### PR DESCRIPTION
The repo URL redirects from `tripit/slate` to `lord/slate`, but the old demo site URL http://tripit.github.io/slate/ throws a 404 error rather than redirecting to the new location http://lord.github.io/slate/, so it's probably best to update both.
